### PR TITLE
Add MoviezWap provider and update manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -144,6 +144,14 @@
     "disabled": true
   },
   {
+    "display_name": "MoviezWap",
+    "value": "Moviezwap",
+    "version": "1.0",
+    "icon": "",
+    "type": "india",
+    "disabled": false
+  },
+  {
     "display_name": "ShowBox",
     "value": "showbox",
     "version": "1.1",

--- a/providers/moviezwap/catalog.ts
+++ b/providers/moviezwap/catalog.ts
@@ -1,0 +1,21 @@
+export const catalog = [
+    {
+      title: "Telugu Movies",
+      filter: "/category/Telugu-(2025)-Movies.html",
+    },
+    {
+      title: "Tamil Movies",
+      filter: "/category/Tamil-(2025)-Movies.html",
+    },
+    {
+      title: "Hollywood Telugu Dubbed",
+      filter: "/category/Telugu-Dubbed-Hollywood-Movies-Complete-Set.html",
+    },
+    {
+      title: "Web Series",
+      filter: "/category/Telugu-Web-Series.html",
+    },
+  ];
+  
+  export const genres = [];
+  

--- a/providers/moviezwap/meta.ts
+++ b/providers/moviezwap/meta.ts
@@ -1,0 +1,89 @@
+import { Info, Link, ProviderContext } from "../types";
+
+export const getMeta = async function ({
+  link,
+  providerContext,
+}: {
+  link: string;
+  providerContext: ProviderContext;
+}): Promise<Info> {
+  try {
+    const { axios, cheerio, getBaseUrl } = providerContext;
+    const baseUrl = await getBaseUrl("moviezwap");
+    const url = link.startsWith("http") ? link : `${baseUrl}${link}`;
+    const res = await axios.get(url);
+    const data = res.data;
+    const $ = cheerio.load(data);
+
+    // 1. Poster image
+    let image = "";
+    // Try to find the poster image (adjust selector as needed)
+    image =
+      $('td:contains("Movie Poster")').next().find("img").attr("src") ||
+      $('img[alt*="Poster"], img[alt*="poster"]').attr("src") ||
+      "";
+    if (image && !image.startsWith("http")) {
+      image = baseUrl + image;
+    }
+
+    // 2. Title
+    const title = $("title").text().replace(" - MoviezWap", "").trim() || "";
+
+    // 3. Info table
+    let synopsis = "";
+    let imdbId = "";
+    let type = "movie";
+    let infoRows: string[] = [];
+    $("td:contains('Movie Information')")
+      .parent()
+      .nextAll("tr")
+      .each((i, el) => {
+        const tds = $(el).find("td");
+        if (tds.length === 2) {
+          const key = tds.eq(0).text().trim();
+          const value = tds.eq(1).text().trim();
+          infoRows.push(`${key}: ${value}`);
+          if (key.toLowerCase().includes("plot")) synopsis = value;
+          if (key.toLowerCase().includes("imdb")) imdbId = value;
+        }
+      });
+    if (!synopsis) {
+      // fallback: try to find a <p> with plot
+      synopsis = $("p:contains('plot')").text().trim();
+    }
+
+    // 4. Download links (multiple qualities)
+    const links: Link[] = [];
+    $('a[href*="download.php?file="]').each((i, el) => {
+      const downloadPage = $(el).attr("href");
+      const text = $(el).text().trim();
+      if (downloadPage && /\d+p/i.test(text)) {
+        // Only add links with quality in text
+        links.push({
+          title: text,
+          directLinks: [{ title: text, link: downloadPage }],
+        });
+      }
+    });
+
+    return {
+      title,
+      synopsis,
+      image,
+      imdbId,
+      type,
+      linkList: links,
+      //info: infoRows.join("\n"),
+    };
+  } catch (err) {
+    console.error(err);
+    return {
+      title: "",
+      synopsis: "",
+      image: "",
+      imdbId: "",
+      type: "movie",
+      linkList: [],
+    };
+  }
+};

--- a/providers/moviezwap/posts.ts
+++ b/providers/moviezwap/posts.ts
@@ -1,0 +1,70 @@
+import { Post, ProviderContext } from "../types";
+
+export const getPosts = async function ({
+  filter,
+  page,
+  signal,
+  providerContext,
+}: {
+  filter: string;
+  page: number;
+  providerValue: string;
+  signal: AbortSignal;
+  providerContext: ProviderContext;
+}): Promise<Post[]> {
+  const { getBaseUrl, cheerio } = providerContext;
+  const baseUrl = await getBaseUrl("moviezwap");
+  const url = `${baseUrl}${filter}`;
+  return posts({ url, signal, cheerio });
+};
+
+export const getSearchPosts = async function ({
+  searchQuery,
+  page,
+  signal,
+  providerContext,
+}: {
+  searchQuery: string;
+  page: number;
+  providerValue: string;
+  signal: AbortSignal;
+  providerContext: ProviderContext;
+}): Promise<Post[]> {
+  const { getBaseUrl, cheerio } = providerContext;
+  const baseUrl = await getBaseUrl("moviezwap");
+  const url = `${baseUrl}/search.php?q=${encodeURIComponent(searchQuery)}`;
+  return posts({ url, signal, cheerio });
+};
+
+async function posts({
+  url,
+  signal,
+  cheerio,
+}: {
+  url: string;
+  signal: AbortSignal;
+  cheerio: ProviderContext["cheerio"];
+}): Promise<Post[]> {
+  try {
+    const res = await fetch(url, { signal });
+    const data = await res.text();
+    const $ = cheerio.load(data);
+    const catalog: Post[] = [];
+    $('a[href^="/movie/"]').each((i, el) => {
+      const title = $(el).text().trim();
+      const link = $(el).attr("href");
+      const image = "";
+      if (title && link) {
+        catalog.push({
+          title: title,
+          link: link,
+          image: image,
+        });
+      }
+    });
+    return catalog;
+  } catch (err) {
+    console.error("moviezwapGetPosts error ", err);
+    return [];
+  }
+}

--- a/providers/moviezwap/stream.ts
+++ b/providers/moviezwap/stream.ts
@@ -1,0 +1,29 @@
+import { ProviderContext } from "../types";
+
+export async function getStream({
+  link,
+  signal,
+  providerContext,
+}: {
+  link: string;
+  type: string;
+  signal: AbortSignal;
+  providerContext: ProviderContext;
+}) {
+  const { axios, cheerio, commonHeaders: headers } = providerContext;
+  const res = await axios.get(link, { headers, signal });
+  const html = res.data;
+  const $ = cheerio.load(html);
+
+  // Find the actual .mp4 download link
+  let downloadLink = null;
+  $('a[href$=".mp4"]').each((i, el) => {
+    const href = $(el).attr("href");
+    if (href && href.endsWith(".mp4")) {
+      downloadLink = href;
+      return false;
+    }
+  });
+
+  return downloadLink ? [{ url: downloadLink }] : [];
+}


### PR DESCRIPTION
## Summary

This pull request adds a new provider for MoviezWap to the project.

### Changes:
- Added `providers/moviezwap/` with all required files (`catalog.ts`, `posts.ts`, `meta.ts`, `stream.ts`)
- Updated `manifest.json` to include the MoviezWap provider

### Details:
- The provider supports catalog, search, metadata, and stream extraction for MoviezWap.
- Tested locally: fetching posts, searching, and metadata extraction all work as expected.

### Base URL
The base URL for MoviezWap (`https://www.moviezwap.pink/`) has also been submitted to the configuration repository.

---

