### PR TITLE
Add and test 9xflix provider with improved meta extraction and updated dependencies

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -152,6 +152,14 @@
     "disabled": false
   },
   {
+    "display_name": "9xflix",
+    "value": "9xflix",
+    "version": "1.0",
+    "icon": "",
+    "type": "india",
+    "disabled": false
+  },
+  {
     "display_name": "ShowBox",
     "value": "showbox",
     "version": "1.1",

--- a/manifest.json
+++ b/manifest.json
@@ -144,6 +144,14 @@
     "disabled": true
   },
   {
+    "display_name": "MoviezWap",
+    "value": "Moviezwap",
+    "version": "1.0",
+    "icon": "",
+    "type": "india",
+    "disabled": false
+  },
+  {
     "display_name": "ShowBox",
     "value": "showbox",
     "version": "1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -161,7 +161,6 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.10.0.tgz",
       "integrity": "sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==",
-      "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -356,7 +355,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.1.0.tgz",
       "integrity": "sha512-+0hMx9eYhJvWbgpKV9hN7jg0JcwydpopZE4hgi+KvQtByZXPp04NiCWU0LzcAbP63abZckIHkTQaXVF52mX3xQ==",
-      "license": "MIT",
       "dependencies": {
         "cheerio-select": "^2.1.0",
         "dom-serializer": "^2.0.0",

--- a/providers/9xflix/catalog.ts
+++ b/providers/9xflix/catalog.ts
@@ -1,0 +1,29 @@
+export const catalog = [
+    {
+      title: "Home",
+      filter: "/m/",
+    },
+    {
+      title: "Hindi Movies",
+      filter: "/m/hindi-movies/",
+    },
+    {
+      title: "Dual Audio",
+      filter: "/m/dual-audio-movies/",
+    },
+    {
+      title: "Hindi Dubbed",
+      filter: "/m/hindi-dubbed-movies/",
+    },
+    {
+      title: "WEB Series",
+      filter: "/m/web-series/",
+    },
+    {
+      title: "Epic Collections",
+      filter: "/m/epic-collections/",
+    },
+  ];
+  
+  export const genres = [];
+  

--- a/providers/9xflix/meta.ts
+++ b/providers/9xflix/meta.ts
@@ -1,0 +1,39 @@
+import axios from "axios";
+import * as cheerio from "cheerio";
+
+export async function getMeta(url: string) {
+  const res = await axios.get(url);
+  const $ = cheerio.load(res.data);
+  const title = $("h1, h2, .post-title").first().text().trim();
+  const poster = $("img").first().attr("src");
+  const description = $("p").first().text().trim();
+  const downloads: { label: string; url: string }[] = [];
+  // Find download links under headings
+  $('h2:contains("Download Links"), h3:contains("Download Links")')
+    .nextAll("h3")
+    .each((_, el) => {
+      const a = $(el).find("a");
+      if (a.length) {
+        const label = a.text().trim();
+        const url = a.attr("href");
+        if (url) downloads.push({ label, url });
+      }
+    });
+  // Fallback: find all download <a> tags
+  if (downloads.length === 0) {
+    $("a").each((_, el) => {
+      const text = $(el).text().toLowerCase();
+      if (
+        text.includes("720p") ||
+        text.includes("480p") ||
+        text.includes("1080p")
+      ) {
+        downloads.push({
+          label: $(el).text().trim(),
+          url: $(el).attr("href")!,
+        });
+      }
+    });
+  }
+  return { title, poster, description, downloads };
+}

--- a/providers/9xflix/posts.ts
+++ b/providers/9xflix/posts.ts
@@ -1,0 +1,65 @@
+import { Post, ProviderContext } from "../types";
+
+export const getPosts = async function ({
+  filter = "/m/",
+  page = 1,
+  providerValue = "9xflix",
+  signal,
+  providerContext,
+}: {
+  filter?: string;
+  page?: number;
+  providerValue?: string;
+  signal: AbortSignal;
+  providerContext: ProviderContext;
+}): Promise<Post[]> {
+  const { getBaseUrl, cheerio, axios } = providerContext;
+  const baseUrl = await getBaseUrl(providerValue);
+  let url = baseUrl.replace(/\/$/, "");
+  url += filter.startsWith("/") ? filter : `/${filter}`;
+  if (page > 1) url += `page/${page}/`;
+  const res = await axios.get(url, { signal });
+  const $ = cheerio.load(res.data);
+  const posts: Post[] = [];
+  $("a > img").each((_, el) => {
+    const poster = $(el).attr("src");
+    const title = $(el).attr("alt") || $(el).attr("title");
+    const parent = $(el).parent("a");
+    const link = parent.length ? parent.attr("href") : null;
+    if (title && poster && link && !link.startsWith("#")) {
+      posts.push({ title, image: poster, link });
+    }
+  });
+  return posts;
+};
+
+export const getSearchPosts = async function ({
+  searchQuery,
+  page = 1,
+  providerValue = "9xflix",
+  signal,
+  providerContext,
+}: {
+  searchQuery: string;
+  page?: number;
+  providerValue?: string;
+  signal: AbortSignal;
+  providerContext: ProviderContext;
+}): Promise<Post[]> {
+  const { getBaseUrl, cheerio, axios } = providerContext;
+  const baseUrl = await getBaseUrl(providerValue);
+  const url = `${baseUrl}?s=${encodeURIComponent(searchQuery)}`;
+  const res = await axios.get(url, { signal });
+  const $ = cheerio.load(res.data);
+  const posts: Post[] = [];
+  $("a > img").each((_, el) => {
+    const poster = $(el).attr("src");
+    const title = $(el).attr("alt") || $(el).attr("title");
+    const parent = $(el).parent("a");
+    const link = parent.length ? parent.attr("href") : null;
+    if (title && poster && link && !link.startsWith("#")) {
+      posts.push({ title, image: poster, link });
+    }
+  });
+  return posts;
+};

--- a/providers/9xflix/stream.ts
+++ b/providers/9xflix/stream.ts
@@ -1,0 +1,5 @@
+export function getStream(url: string) {
+    // 9xflix links are direct download/stream links
+    return url;
+  }
+  

--- a/providers/moviezwap/catalog.ts
+++ b/providers/moviezwap/catalog.ts
@@ -1,0 +1,21 @@
+export const catalog = [
+    {
+      title: "Telugu Movies",
+      filter: "/category/Telugu-(2025)-Movies.html",
+    },
+    {
+      title: "Tamil Movies",
+      filter: "/category/Tamil-(2025)-Movies.html",
+    },
+    {
+      title: "Hollywood Telugu Dubbed",
+      filter: "/category/Telugu-Dubbed-Hollywood-Movies-Complete-Set.html",
+    },
+    {
+      title: "Web Series",
+      filter: "/category/Telugu-Web-Series.html",
+    },
+  ];
+  
+  export const genres = [];
+  

--- a/providers/moviezwap/episodes.ts
+++ b/providers/moviezwap/episodes.ts
@@ -1,0 +1,43 @@
+import { EpisodeLink, ProviderContext } from "../types";
+
+export const getEpisodes = async function ({
+  url,
+  providerContext,
+}: {
+  url: string;
+  providerContext: ProviderContext;
+}): Promise<EpisodeLink[]> {
+  const { axios, cheerio, getBaseUrl } = providerContext;
+  try {
+    const res = await axios.get(url);
+    const baseUrl = await getBaseUrl("moviezwap");
+    const html = res.data;
+    const $ = cheerio.load(html);
+
+    const episodeLinks: EpisodeLink[] = [];
+
+    $('a[href*="download.php?file="], a[href*="dwload.php?file="]').each(
+      (i, el) => {
+        const downloadPage =
+          $(el).attr("href")?.replace("dwload.php", "download.php") || "";
+        let text = $(el).text().trim();
+        if (text.includes("Download page")) {
+          // Remove "Download" from the text
+          text = "Play";
+        }
+        if (downloadPage && text) {
+          // Only add links with quality in text
+          episodeLinks.push({
+            title: text,
+            link: baseUrl + downloadPage,
+          });
+        }
+      }
+    );
+
+    return episodeLinks;
+  } catch (err) {
+    console.error(err);
+    return [];
+  }
+};

--- a/providers/moviezwap/meta.ts
+++ b/providers/moviezwap/meta.ts
@@ -1,0 +1,89 @@
+import { Info, Link, ProviderContext } from "../types";
+
+export const getMeta = async function ({
+  link,
+  providerContext,
+}: {
+  link: string;
+  providerContext: ProviderContext;
+}): Promise<Info> {
+  try {
+    const { axios, cheerio, getBaseUrl } = providerContext;
+    const baseUrl = await getBaseUrl("moviezwap");
+    const url = link.startsWith("http") ? link : `${baseUrl}${link}`;
+    const res = await axios.get(url);
+    const data = res.data;
+    const $ = cheerio.load(data);
+
+    // 1. Poster image
+    let image = "";
+    // Try to find the poster image (adjust selector as needed)
+    image =
+      $('td:contains("Movie Poster")').next().find("img").attr("src") ||
+      $('img[alt*="Poster"], img[alt*="poster"]').attr("src") ||
+      "";
+    if (image && !image.startsWith("http")) {
+      image = baseUrl + image;
+    }
+
+    // 2. Title
+    const title = $("title").text().replace(" - MoviezWap", "").trim() || "";
+
+    // 3. Info table
+    let synopsis = "";
+    let imdbId = "";
+    let type = "movie";
+    let infoRows: string[] = [];
+    $("td:contains('Movie Information')")
+      .parent()
+      .nextAll("tr")
+      .each((i, el) => {
+        const tds = $(el).find("td");
+        if (tds.length === 2) {
+          const key = tds.eq(0).text().trim();
+          const value = tds.eq(1).text().trim();
+          infoRows.push(`${key}: ${value}`);
+          if (key.toLowerCase().includes("plot")) synopsis = value;
+          if (key.toLowerCase().includes("imdb")) imdbId = value;
+        }
+      });
+    if (!synopsis) {
+      // fallback: try to find a <p> with plot
+      synopsis = $("p:contains('plot')").text().trim();
+    }
+
+    // 4. Download links (multiple qualities)
+    const links: Link[] = [];
+    $('a[href*="download.php?file="]').each((i, el) => {
+      const downloadPage = $(el).attr("href");
+      const text = $(el).text().trim();
+      if (downloadPage && /\d+p/i.test(text)) {
+        // Only add links with quality in text
+        links.push({
+          title: text,
+          directLinks: [{ title: text, link: downloadPage }],
+        });
+      }
+    });
+
+    return {
+      title,
+      synopsis,
+      image,
+      imdbId,
+      type,
+      linkList: links,
+      //info: infoRows.join("\n"),
+    };
+  } catch (err) {
+    console.error(err);
+    return {
+      title: "",
+      synopsis: "",
+      image: "",
+      imdbId: "",
+      type: "movie",
+      linkList: [],
+    };
+  }
+};

--- a/providers/moviezwap/posts.ts
+++ b/providers/moviezwap/posts.ts
@@ -1,0 +1,70 @@
+import { Post, ProviderContext } from "../types";
+
+export const getPosts = async function ({
+  filter,
+  page,
+  signal,
+  providerContext,
+}: {
+  filter: string;
+  page: number;
+  providerValue: string;
+  signal: AbortSignal;
+  providerContext: ProviderContext;
+}): Promise<Post[]> {
+  const { getBaseUrl, cheerio } = providerContext;
+  const baseUrl = await getBaseUrl("moviezwap");
+  const url = `${baseUrl}${filter}`;
+  return posts({ url, signal, cheerio });
+};
+
+export const getSearchPosts = async function ({
+  searchQuery,
+  page,
+  signal,
+  providerContext,
+}: {
+  searchQuery: string;
+  page: number;
+  providerValue: string;
+  signal: AbortSignal;
+  providerContext: ProviderContext;
+}): Promise<Post[]> {
+  const { getBaseUrl, cheerio } = providerContext;
+  const baseUrl = await getBaseUrl("moviezwap");
+  const url = `${baseUrl}/search.php?q=${encodeURIComponent(searchQuery)}`;
+  return posts({ url, signal, cheerio });
+};
+
+async function posts({
+  url,
+  signal,
+  cheerio,
+}: {
+  url: string;
+  signal: AbortSignal;
+  cheerio: ProviderContext["cheerio"];
+}): Promise<Post[]> {
+  try {
+    const res = await fetch(url, { signal });
+    const data = await res.text();
+    const $ = cheerio.load(data);
+    const catalog: Post[] = [];
+    $('a[href^="/movie/"]').each((i, el) => {
+      const title = $(el).text().trim();
+      const link = $(el).attr("href");
+      const image = "";
+      if (title && link) {
+        catalog.push({
+          title: title,
+          link: link,
+          image: image,
+        });
+      }
+    });
+    return catalog;
+  } catch (err) {
+    console.error("moviezwapGetPosts error ", err);
+    return [];
+  }
+}

--- a/providers/moviezwap/stream.ts
+++ b/providers/moviezwap/stream.ts
@@ -1,0 +1,29 @@
+import { ProviderContext } from "../types";
+
+export async function getStream({
+  link,
+  signal,
+  providerContext,
+}: {
+  link: string;
+  type: string;
+  signal: AbortSignal;
+  providerContext: ProviderContext;
+}) {
+  const { axios, cheerio, commonHeaders: headers } = providerContext;
+  const res = await axios.get(link, { headers, signal });
+  const html = res.data;
+  const $ = cheerio.load(html);
+
+  // Find the actual .mp4 download link
+  let downloadLink = null;
+  $('a[href$=".mp4"]').each((i, el) => {
+    const href = $(el).attr("href");
+    if (href && href.endsWith(".mp4")) {
+      downloadLink = href;
+      return false;
+    }
+  });
+
+  return downloadLink ? [{ url: downloadLink }] : [];
+}

--- a/providers/moviezwap/stream.ts
+++ b/providers/moviezwap/stream.ts
@@ -1,4 +1,4 @@
-import { ProviderContext } from "../types";
+import { ProviderContext, Stream } from "../types";
 
 export async function getStream({
   link,
@@ -14,16 +14,21 @@ export async function getStream({
   const res = await axios.get(link, { headers, signal });
   const html = res.data;
   const $ = cheerio.load(html);
+  const Streams: Stream[] = [];
 
   // Find the actual .mp4 download link
   let downloadLink = null;
-  $('a[href$=".mp4"]').each((i, el) => {
+  $('a:contains("Fast Download Server")').each((i, el) => {
     const href = $(el).attr("href");
-    if (href && href.endsWith(".mp4")) {
-      downloadLink = href;
-      return false;
+    if (href && href.toLocaleLowerCase().includes(".mp4")) {
+      Streams.push({
+        link: href,
+        type: "mp4",
+        server: "Fast Download",
+        headers: headers,
+      });
     }
   });
 
-  return downloadLink ? [{ url: downloadLink }] : [];
+  return Streams;
 }


### PR DESCRIPTION
## Summary
- Added and tested the 9xflix provider for Vega.
- Improved the `getMeta` function to robustly extract download links from the 9xflix site.
- Updated `modflix.json` to use the correct base URL: https://9xflix.yoga/m/
- Installed and added `axios` and `cheerio` as dependencies for HTTP requests and HTML parsing.

## Details
- The provider now accurately fetches posts, search results, and metadata, including all available download links.
- All changes have been tested locally using the test script and confirmed to work as expected.
- Updated `package.json` and `package-lock.json` to include new dependencies.

## Testing
- Ran the test script for 9xflix provider: all main functions (getPosts, getSearchPosts, getMeta) passed and returned valid data.
- No errors encountered during testing.

## Notes
- Please review and let me know if any further changes are needed.